### PR TITLE
Fix nav duplication: extract NAV_LINKS shared config

### DIFF
--- a/libs/shared/src/lib/components/index.ts
+++ b/libs/shared/src/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from './main-toolbar';
+export * from './nav-links';
 export * from './page-container';
 export * from './page-toolbar-button';
 export * from './page-toolbar';

--- a/libs/shared/src/lib/components/main-toolbar.ts
+++ b/libs/shared/src/lib/components/main-toolbar.ts
@@ -10,6 +10,8 @@ import { MatToolbar } from '@angular/material/toolbar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 
+import { NAV_LINKS } from './nav-links';
+
 @Component({
   imports: [MatIcon, MatToolbar, MatTooltip, RouterLink, MatIconButton],
   selector: 'lib-main-toolbar',
@@ -83,22 +85,16 @@ import { RouterLink } from '@angular/router';
       </a>
       <span class="flex-1"></span>
       <div class="hidden md:flex gap-2">
-        <button
-          mat-icon-button
-          [routerLink]="['/weather-forecast']"
-          matTooltip="Get Data Feature"
-          aria-label="Get Data Feature"
-        >
-          <mat-icon>get_app</mat-icon>
-        </button>
-        <button
-          mat-icon-button
-          [routerLink]="['/feature']"
-          matTooltip="Lazy Loaded Feature"
-          aria-label="Lazy Loaded Feature"
-        >
-          <mat-icon>hotel</mat-icon>
-        </button>
+        @for (link of navLinks; track link.routerLink) {
+          <button
+            mat-icon-button
+            [routerLink]="link.routerLink"
+            [matTooltip]="link.hint"
+            [attr.aria-label]="link.hint"
+          >
+            <mat-icon>{{ link.icon }}</mat-icon>
+          </button>
+        }
         @if (loggedIn()) {
           <button
             mat-icon-button
@@ -129,6 +125,8 @@ import { RouterLink } from '@angular/router';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MainToolbar {
+  readonly navLinks = NAV_LINKS;
+
   loggedIn = input<boolean>(null);
 
   toggleSidenav = output<void>();

--- a/libs/shared/src/lib/components/nav-links.ts
+++ b/libs/shared/src/lib/components/nav-links.ts
@@ -1,0 +1,21 @@
+export interface NavLink {
+  routerLink: string;
+  icon: string;
+  hint: string;
+  label: string;
+}
+
+export const NAV_LINKS: NavLink[] = [
+  {
+    routerLink: '/weather-forecast',
+    icon: 'get_app',
+    hint: 'Get Data Feature',
+    label: 'Weather Forecasts',
+  },
+  {
+    routerLink: '/feature',
+    icon: 'hotel',
+    hint: 'Lazy Loaded Feature',
+    label: 'Counter',
+  },
+];

--- a/libs/shared/src/lib/components/sidenav.ts
+++ b/libs/shared/src/lib/components/sidenav.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, output } from '@angular/core';
 import { MatNavList } from '@angular/material/list';
 
+import { NAV_LINKS } from './nav-links';
 import { SidenavListItem } from './sidenav-list-item';
 
 @Component({
@@ -9,22 +10,16 @@ import { SidenavListItem } from './sidenav-list-item';
   template: `
     <div class="p-2">
       <mat-nav-list>
-        <lib-sidenav-list-item
-          (navigate)="closeSidenav.emit()"
-          routerLink="/weather-forecast"
-          icon="get_app"
-          hint="Get Data Feature"
-        >
-          <span>Weather Forecasts</span>
-        </lib-sidenav-list-item>
-        <lib-sidenav-list-item
-          (navigate)="closeSidenav.emit()"
-          routerLink="/feature"
-          icon="hotel"
-          hint="Lazy Loaded Feature"
-        >
-          <span>Counter</span>
-        </lib-sidenav-list-item>
+        @for (link of navLinks; track link.routerLink) {
+          <lib-sidenav-list-item
+            (navigate)="closeSidenav.emit()"
+            [routerLink]="link.routerLink"
+            [icon]="link.icon"
+            [hint]="link.hint"
+          >
+            <span>{{ link.label }}</span>
+          </lib-sidenav-list-item>
+        }
       </mat-nav-list>
     </div>
   `,
@@ -34,6 +29,8 @@ import { SidenavListItem } from './sidenav-list-item';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Sidenav {
+  readonly navLinks = NAV_LINKS;
+
   toggleSidenav = output();
   closeSidenav = output();
 }


### PR DESCRIPTION
Closes #21

## Changes

- Added `NavLink` interface and `NAV_LINKS` constant to a new `nav-links.ts` file in the shared components
- Refactored `Sidenav` to loop over `NAV_LINKS` with `@for` instead of duplicating each item
- Refactored `MainToolbar` to loop over `NAV_LINKS` with `@for` instead of duplicating each item
- Exported `NavLink` and `NAV_LINKS` from the shared lib's public API

Adding a new nav route now requires a single entry in `nav-links.ts` — no more updating two components.