### PR TITLE
refactor: convert services from InjectionToken to @Injectable classes (#22)

### DIFF
--- a/libs/auth/src/lib/services/auth.service.ts
+++ b/libs/auth/src/lib/services/auth.service.ts
@@ -1,26 +1,20 @@
 import { HttpBackend, HttpClient } from '@angular/common/http';
-import { InjectionToken, inject } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { AuthResponse, Login, Refresh } from '../state/auth.store';
 
-// HttpBackend is used directly (bypassing interceptors) to avoid an infinite
-// loop: the auth interceptor would otherwise intercept its own refresh/login
-// requests and try to refresh again on 401.
-const authServiceFactory = (httpBackend = inject(HttpBackend)) => {
-  const http = new HttpClient(httpBackend);
-  return {
-    login(login: Login) {
-      return http.post<AuthResponse>('/api/account/login', login);
-    },
-    refresh(refresh: Refresh) {
-      return http.post<AuthResponse>('/api/account/refresh', refresh);
-    },
-  };
-};
+// HttpBackend is injected directly (bypassing interceptors) to avoid an
+// infinite loop: the auth interceptor would otherwise intercept its own
+// refresh/login requests and try to refresh again on 401.
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly http = new HttpClient(inject(HttpBackend));
 
-export const AuthService = new InjectionToken('AuthService', {
-  providedIn: 'root',
-  factory: authServiceFactory,
-});
+  login(login: Login) {
+    return this.http.post<AuthResponse>('/api/account/login', login);
+  }
 
-export type AuthService = ReturnType<typeof authServiceFactory>;
+  refresh(refresh: Refresh) {
+    return this.http.post<AuthResponse>('/api/account/refresh', refresh);
+  }
+}

--- a/libs/weather-forecast/src/lib/services/weather-forecast.service.ts
+++ b/libs/weather-forecast/src/lib/services/weather-forecast.service.ts
@@ -1,17 +1,21 @@
 import { HttpClient, httpResource } from '@angular/common/http';
-import { InjectionToken, Signal, inject } from '@angular/core';
+import { Injectable, Signal, inject } from '@angular/core';
 
 import { WeatherForecast } from '../models/weather-forecast';
 
-export const weatherForecastServiceFactory = (http = inject(HttpClient)) => ({
+@Injectable({ providedIn: 'root' })
+export class WeatherForecastService {
+  private readonly http = inject(HttpClient);
+
   getForecasts(count: number, plus: boolean) {
-    return http.get<WeatherForecast[]>(
+    return this.http.get<WeatherForecast[]>(
       plus ? '/api/weatherforecastsplus' : '/api/weatherforecasts',
       {
         params: { count },
       },
     );
-  },
+  }
+
   getForecastsHttpResource(request: Signal<{ count: number; plus: boolean }>) {
     return httpResource<WeatherForecast[]>(() => ({
       url: request().plus
@@ -19,17 +23,5 @@ export const weatherForecastServiceFactory = (http = inject(HttpClient)) => ({
         : '/api/weatherforecasts',
       params: { count: request().count },
     }));
-  },
-});
-
-export const WeatherForecastService = new InjectionToken(
-  'WeatherForecastService',
-  {
-    providedIn: 'root',
-    factory: weatherForecastServiceFactory,
-  },
-);
-
-export type WeatherForecastService = ReturnType<
-  typeof weatherForecastServiceFactory
->;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #22

Refactors `AuthService` and `WeatherForecastService` from the unconventional `InjectionToken`/factory+type pattern to standard `@Injectable()` classes.

## Changes

- **`AuthService`**: Converted to `@Injectable({ providedIn: 'root' })` class. `HttpBackend` is injected directly (bypassing HTTP interceptors) to avoid an infinite refresh loop on 401 responses — this behaviour is preserved.
- **`WeatherForecastService`**: Converted to `@Injectable({ providedIn: 'root' })` class with a private `http` field via `inject(HttpClient)`.

## Why

The old `const`/`type` name collision pattern is unconventional, reduces IDE support (jump-to-definition, auto-import), and makes the code harder to follow for new contributors.

## Testing

All existing tests pass with no changes required.