### PR TITLE
test: add unit tests for breakpoint/sw-update stores and E2E tests (#25)

### DIFF
--- a/apps/web-app-e2e/src/login.e2e.spec.ts
+++ b/apps/web-app-e2e/src/login.e2e.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Login page', () => {
+  test('should load the login page', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.getByTestId('lib-login')).toBeVisible();
+  });
+
+  test('should display email and password fields', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+  });
+
+  test('should display a Login button', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.getByRole('button', { name: /login/i })).toBeVisible();
+  });
+
+  test('login button should be disabled when form is invalid', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+
+    // Clear the pre-filled email so the form becomes invalid
+    await page.getByLabel('Email').fill('');
+
+    await expect(page.getByRole('button', { name: /login/i })).toBeDisabled();
+  });
+
+  test('login button should be enabled when form is valid', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+
+    await page.getByLabel('Email').fill('user@example.com');
+    await page.getByLabel('Password').fill('password123');
+
+    await expect(page.getByRole('button', { name: /login/i })).toBeEnabled();
+  });
+});

--- a/apps/web-app-e2e/src/navigation.e2e.spec.ts
+++ b/apps/web-app-e2e/src/navigation.e2e.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test.describe('toolbar (desktop)', () => {
+    test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('should navigate to weather forecast page via toolbar button', async ({
+      page,
+    }) => {
+      await page.goto('/');
+
+      await page.getByRole('button', { name: 'Get Data Feature' }).click();
+
+      await expect(page).toHaveURL(/\/weather-forecast/);
+      await expect(page.getByTestId('lib-weather-forecast')).toBeVisible();
+    });
+
+    test('should navigate to counter page via toolbar button', async ({
+      page,
+    }) => {
+      await page.goto('/');
+
+      await page.getByRole('button', { name: 'Lazy Loaded Feature' }).click();
+
+      await expect(page).toHaveURL(/\/feature/);
+      await expect(page.getByTestId('lib-counter-container')).toBeVisible();
+    });
+
+    test('should navigate home via logo link', async ({ page }) => {
+      await page.goto('/feature');
+
+      await page.getByRole('link', { name: 'Home Page' }).click();
+
+      await expect(page).toHaveURL(/\/$/);
+      await expect(page.getByTestId('lib-home')).toBeVisible();
+    });
+  });
+
+  test.describe('sidenav (mobile)', () => {
+    test.use({ viewport: { width: 375, height: 812 } });
+
+    test('should open sidenav and navigate to weather forecast', async ({
+      page,
+    }) => {
+      await page.goto('/');
+
+      await page.getByRole('button', { name: 'Toggle side menu' }).click();
+
+      await expect(page.getByTestId('lib-sidenav')).toBeVisible();
+
+      await page.getByRole('link', { name: /weather forecasts/i }).click();
+
+      await expect(page).toHaveURL(/\/weather-forecast/);
+    });
+
+    test('should open sidenav and navigate to counter', async ({ page }) => {
+      await page.goto('/');
+
+      await page.getByRole('button', { name: 'Toggle side menu' }).click();
+
+      await expect(page.getByTestId('lib-sidenav')).toBeVisible();
+
+      await page.getByRole('link', { name: /counter/i }).click();
+
+      await expect(page).toHaveURL(/\/feature/);
+    });
+  });
+});

--- a/apps/web-app-e2e/src/weather-forecast.e2e.spec.ts
+++ b/apps/web-app-e2e/src/weather-forecast.e2e.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Weather Forecast page', () => {
+  test('should load the weather forecast component', async ({ page }) => {
+    await page.goto('/weather-forecast');
+
+    await expect(page.getByTestId('lib-weather-forecast')).toBeVisible();
+  });
+
+  test('should display page toolbar with title', async ({ page }) => {
+    await page.goto('/weather-forecast');
+
+    const toolbar = page.getByTestId('lib-page-toolbar');
+    await expect(toolbar).toBeVisible();
+    await expect(toolbar).toContainText(/weather/i);
+  });
+
+  test('should contain a forecast table', async ({ page }) => {
+    await page.goto('/weather-forecast');
+
+    await expect(page.getByTestId('lib-forecast-table')).toBeVisible();
+  });
+
+  test('should have a Get Forecasts button', async ({ page }) => {
+    await page.goto('/weather-forecast');
+
+    await expect(
+      page.getByRole('button', { name: /get forecasts/i }),
+    ).toBeVisible();
+  });
+});

--- a/libs/shared/src/lib/state/breakpoint.store.spec.ts
+++ b/libs/shared/src/lib/state/breakpoint.store.spec.ts
@@ -1,0 +1,166 @@
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+
+import { BreakpointStore } from './breakpoint.store';
+
+describe('BreakpointStore', () => {
+  let store: BreakpointStore;
+  let breakpointSubject: Subject<{
+    breakpoints: Record<string, boolean>;
+    matches: boolean;
+  }>;
+
+  const ALL_BREAKPOINTS = [
+    Breakpoints.XSmall,
+    Breakpoints.Small,
+    Breakpoints.Medium,
+    Breakpoints.Large,
+    Breakpoints.XLarge,
+    Breakpoints.HandsetPortrait,
+    Breakpoints.TabletPortrait,
+    Breakpoints.WebPortrait,
+    Breakpoints.HandsetLandscape,
+    Breakpoints.TabletLandscape,
+    Breakpoints.WebLandscape,
+  ];
+
+  function emitBreakpoints(active: string[]) {
+    const breakpoints: Record<string, boolean> = Object.fromEntries(
+      ALL_BREAKPOINTS.map((bp) => [bp, active.includes(bp)]),
+    );
+    breakpointSubject.next({ breakpoints, matches: active.length > 0 });
+  }
+
+  beforeEach(() => {
+    breakpointSubject = new Subject();
+
+    TestBed.configureTestingModule({
+      providers: [
+        BreakpointStore,
+        {
+          provide: BreakpointObserver,
+          useValue: { observe: () => breakpointSubject.asObservable() },
+        },
+      ],
+    });
+
+    store = TestBed.inject(BreakpointStore);
+  });
+
+  it('should be created', () => {
+    expect(store).toBeDefined();
+  });
+
+  it('should initialise with all breakpoints false', () => {
+    expect(store.xsmall()).toBe(false);
+    expect(store.small()).toBe(false);
+    expect(store.medium()).toBe(false);
+    expect(store.large()).toBe(false);
+    expect(store.xlarge()).toBe(false);
+    expect(store.handset()).toBe(false);
+    expect(store.tablet()).toBe(false);
+    expect(store.web()).toBe(false);
+    expect(store.handsetPortrait()).toBe(false);
+    expect(store.tabletPortrait()).toBe(false);
+    expect(store.webPortrait()).toBe(false);
+    expect(store.handsetLandscape()).toBe(false);
+    expect(store.tabletLandscape()).toBe(false);
+    expect(store.webLandscape()).toBe(false);
+  });
+
+  it('should set xsmall when XSmall breakpoint matches', () => {
+    emitBreakpoints([Breakpoints.XSmall]);
+    expect(store.xsmall()).toBe(true);
+    expect(store.small()).toBe(false);
+  });
+
+  it('should set small when Small breakpoint matches', () => {
+    emitBreakpoints([Breakpoints.Small]);
+    expect(store.small()).toBe(true);
+    expect(store.xsmall()).toBe(false);
+  });
+
+  it('should set medium when Medium breakpoint matches', () => {
+    emitBreakpoints([Breakpoints.Medium]);
+    expect(store.medium()).toBe(true);
+  });
+
+  it('should set large when Large breakpoint matches', () => {
+    emitBreakpoints([Breakpoints.Large]);
+    expect(store.large()).toBe(true);
+  });
+
+  it('should set xlarge when XLarge breakpoint matches', () => {
+    emitBreakpoints([Breakpoints.XLarge]);
+    expect(store.xlarge()).toBe(true);
+  });
+
+  it('should set handset and handsetPortrait when HandsetPortrait matches', () => {
+    emitBreakpoints([Breakpoints.HandsetPortrait]);
+    expect(store.handset()).toBe(true);
+    expect(store.handsetPortrait()).toBe(true);
+    expect(store.handsetLandscape()).toBe(false);
+  });
+
+  it('should set handset and handsetLandscape when HandsetLandscape matches', () => {
+    emitBreakpoints([Breakpoints.HandsetLandscape]);
+    expect(store.handset()).toBe(true);
+    expect(store.handsetLandscape()).toBe(true);
+    expect(store.handsetPortrait()).toBe(false);
+  });
+
+  it('should set tablet and tabletPortrait when TabletPortrait matches', () => {
+    emitBreakpoints([Breakpoints.TabletPortrait]);
+    expect(store.tablet()).toBe(true);
+    expect(store.tabletPortrait()).toBe(true);
+    expect(store.tabletLandscape()).toBe(false);
+  });
+
+  it('should set tablet and tabletLandscape when TabletLandscape matches', () => {
+    emitBreakpoints([Breakpoints.TabletLandscape]);
+    expect(store.tablet()).toBe(true);
+    expect(store.tabletLandscape()).toBe(true);
+    expect(store.tabletPortrait()).toBe(false);
+  });
+
+  it('should set web and webPortrait when WebPortrait matches', () => {
+    emitBreakpoints([Breakpoints.WebPortrait]);
+    expect(store.web()).toBe(true);
+    expect(store.webPortrait()).toBe(true);
+    expect(store.webLandscape()).toBe(false);
+  });
+
+  it('should set web and webLandscape when WebLandscape matches', () => {
+    emitBreakpoints([Breakpoints.WebLandscape]);
+    expect(store.web()).toBe(true);
+    expect(store.webLandscape()).toBe(true);
+    expect(store.webPortrait()).toBe(false);
+  });
+
+  it('should update multiple signals simultaneously', () => {
+    emitBreakpoints([Breakpoints.Large, Breakpoints.WebLandscape]);
+    expect(store.large()).toBe(true);
+    expect(store.web()).toBe(true);
+    expect(store.webLandscape()).toBe(true);
+    expect(store.small()).toBe(false);
+  });
+
+  it('should clear previous signals when breakpoints change', () => {
+    emitBreakpoints([Breakpoints.XSmall]);
+    expect(store.xsmall()).toBe(true);
+
+    emitBreakpoints([Breakpoints.Large]);
+    expect(store.xsmall()).toBe(false);
+    expect(store.large()).toBe(true);
+  });
+
+  it('should set all signals to false when no breakpoints match', () => {
+    emitBreakpoints([Breakpoints.HandsetPortrait]);
+    expect(store.handset()).toBe(true);
+
+    emitBreakpoints([]);
+    expect(store.handset()).toBe(false);
+    expect(store.handsetPortrait()).toBe(false);
+  });
+});

--- a/libs/shared/src/lib/state/sw-update.store.spec.ts
+++ b/libs/shared/src/lib/state/sw-update.store.spec.ts
@@ -1,0 +1,141 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SwUpdate, VersionEvent } from '@angular/service-worker';
+import { EMPTY, Subject } from 'rxjs';
+
+import { SwUpdateStore, swUpdateInitialState } from './sw-update.store';
+
+describe('SwUpdateStore', () => {
+  let store: SwUpdateStore;
+  let snackBar: MatSnackBar;
+  let versionUpdatesSubject: Subject<VersionEvent>;
+
+  function setup(isEnabled: boolean) {
+    versionUpdatesSubject = new Subject<VersionEvent>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideNoopAnimations(),
+        SwUpdateStore,
+        {
+          provide: SwUpdate,
+          useValue: {
+            isEnabled,
+            versionUpdates: versionUpdatesSubject.asObservable(),
+            activateUpdate: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    });
+
+    store = TestBed.inject(SwUpdateStore);
+    snackBar = TestBed.inject(MatSnackBar);
+  }
+
+  beforeEach(() => setup(true));
+
+  it('should be created', () => {
+    expect(store).toBeDefined();
+  });
+
+  it('should have correct initial state', () => {
+    expect(store.message()).toBe(swUpdateInitialState.message);
+    expect(store.action()).toBe(swUpdateInitialState.action);
+    expect(store.snackbarConfig()).toEqual(swUpdateInitialState.snackbarConfig);
+  });
+
+  it('updateReady should be false initially', () => {
+    expect(store.updateReady()).toBe(false);
+  });
+
+  it('updateReady should be true when a VERSION_READY event is received', () => {
+    versionUpdatesSubject.next({
+      type: 'VERSION_READY',
+      currentVersion: { hash: 'abc', appData: null },
+      latestVersion: { hash: 'def', appData: null },
+    } as VersionEvent);
+
+    expect(store.updateReady()).toBe(true);
+  });
+
+  it('updateReady should remain false for VERSION_DETECTED events', () => {
+    versionUpdatesSubject.next({
+      type: 'VERSION_DETECTED',
+      version: { hash: 'def', appData: null },
+    } as VersionEvent);
+
+    expect(store.updateReady()).toBe(false);
+  });
+
+  it('updateReady should remain false for VERSION_INSTALLATION_FAILED events', () => {
+    versionUpdatesSubject.next({
+      type: 'VERSION_INSTALLATION_FAILED',
+      version: { hash: 'def', appData: null },
+      error: 'install failed',
+    } as VersionEvent);
+
+    expect(store.updateReady()).toBe(false);
+  });
+
+  it('should open snackbar with correct args when VERSION_READY event is received', () => {
+    const openSpy = vi.spyOn(snackBar, 'open').mockReturnValue({
+      onAction: () => EMPTY,
+      dismiss: vi.fn(),
+      afterDismissed: () => EMPTY,
+      afterOpened: () => EMPTY,
+      instance: {} as never,
+      containerInstance: {} as never,
+    });
+
+    versionUpdatesSubject.next({
+      type: 'VERSION_READY',
+      currentVersion: { hash: 'abc', appData: null },
+      latestVersion: { hash: 'def', appData: null },
+    } as VersionEvent);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      swUpdateInitialState.message,
+      swUpdateInitialState.action,
+      swUpdateInitialState.snackbarConfig,
+    );
+  });
+
+  it('should not open snackbar for VERSION_DETECTED events', () => {
+    const openSpy = vi.spyOn(snackBar, 'open');
+
+    versionUpdatesSubject.next({
+      type: 'VERSION_DETECTED',
+      version: { hash: 'def', appData: null },
+    } as VersionEvent);
+
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not open snackbar for VERSION_INSTALLATION_FAILED events', () => {
+    const openSpy = vi.spyOn(snackBar, 'open');
+
+    versionUpdatesSubject.next({
+      type: 'VERSION_INSTALLATION_FAILED',
+      version: { hash: 'def', appData: null },
+      error: 'install failed',
+    } as VersionEvent);
+
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not subscribe to versionUpdates when SwUpdate is disabled', () => {
+    TestBed.resetTestingModule();
+    setup(false);
+
+    const openSpy = vi.spyOn(snackBar, 'open');
+
+    versionUpdatesSubject.next({
+      type: 'VERSION_READY',
+      currentVersion: { hash: 'abc', appData: null },
+      latestVersion: { hash: 'def', appData: null },
+    } as VersionEvent);
+
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #25

Addresses the two untested stores and expands Playwright E2E coverage.

## Unit tests added

### `breakpoint.store.spec.ts` (16 tests)
- Initial state: all breakpoint signals are `false`
- Each named breakpoint signal (`xsmall`, `small`, `medium`, `large`, `xlarge`)
- Composite signals: `handset` is true for either portrait or landscape; same for `tablet` and `web`
- Signals clear correctly when breakpoint changes

### `sw-update.store.spec.ts` (10 tests)
- Initial state and default message/action values
- `updateReady` computed is `false` by default and `true` only on `VERSION_READY`
- Snackbar opened with correct args on `VERSION_READY`
- Snackbar NOT opened for `VERSION_DETECTED` or `VERSION_INSTALLATION_FAILED`
- No subscription when `SwUpdate.isEnabled` is `false`

## E2E tests added (Playwright)

### `navigation.e2e.spec.ts`
- Desktop: toolbar button routes to `/weather-forecast` and `/feature`
- Desktop: logo link returns to `/`
- Mobile (375px): hamburger opens sidenav, nav links route correctly

### `login.e2e.spec.ts`
- Login page loads, form fields visible
- Login button disabled when form is invalid, enabled when valid

### `weather-forecast.e2e.spec.ts`
- Page component visible, toolbar shows title
- Forecast table present, Get Forecasts button accessible