### PR TITLE
feat: Lighthouse performance and a11y improvements

### DIFF
--- a/apps/web-app/src/app/app.config.ts
+++ b/apps/web-app/src/app/app.config.ts
@@ -10,9 +10,11 @@ import {
 } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import {
+  PreloadAllModules,
   provideRouter,
   withComponentInputBinding,
   withEnabledBlockingInitialNavigation,
+  withPreloading,
 } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { authInterceptor } from '@myorg/auth';
@@ -27,6 +29,7 @@ export const appConfig: ApplicationConfig = {
       routes,
       withComponentInputBinding(),
       withEnabledBlockingInitialNavigation(),
+      withPreloading(PreloadAllModules),
     ),
     provideAnimations(),
     provideServiceWorker('/ngsw-worker.js', {

--- a/apps/web-app/src/app/app.ts
+++ b/apps/web-app/src/app/app.ts
@@ -1,6 +1,8 @@
+import { DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSidenav, MatSidenavContainer } from '@angular/material/sidenav';
-import { RouterOutlet } from '@angular/router';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { AuthStore } from '@myorg/auth';
 import {
   LayoutStore,
@@ -8,6 +10,7 @@ import {
   Sidenav,
   SwUpdateStore,
 } from '@myorg/shared';
+import { filter } from 'rxjs/operators';
 
 @Component({
   imports: [
@@ -19,6 +22,7 @@ import {
   ],
   selector: 'app-root',
   template: `
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <lib-main-toolbar
       (toggleSidenav)="store.toggleSidenav()"
       (logout)="authStore.logout(authStore.pageRequiresLogin())"
@@ -35,7 +39,9 @@ import {
           (closeSidenav)="store.closeSidenav()"
         />
       </mat-sidenav>
-      <router-outlet />
+      <main id="main-content" tabindex="-1">
+        <router-outlet />
+      </main>
     </mat-sidenav-container>
   `,
   styles: [
@@ -43,6 +49,28 @@ import {
       .mat-drawer-container {
         margin-top: var(--mat-toolbar-standard-height);
         height: calc(100% - var(--mat-toolbar-standard-height));
+      }
+
+      .skip-link {
+        position: absolute;
+        left: -9999px;
+        top: 0;
+        z-index: 9999;
+        padding: 8px 16px;
+        background: #000;
+        color: #fff;
+        text-decoration: none;
+        border-radius: 0 0 4px 0;
+
+        &:focus {
+          left: 0;
+        }
+      }
+
+      main {
+        outline: none;
+        height: 100%;
+        overflow: auto;
       }
     `,
   ],
@@ -56,4 +84,19 @@ export class App {
   readonly swUpdateStore = inject(SwUpdateStore);
   readonly store = inject(LayoutStore);
   readonly authStore = inject(AuthStore);
+
+  private readonly router = inject(Router);
+  private readonly document = inject(DOCUMENT);
+
+  constructor() {
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntilDestroyed(),
+      )
+      .subscribe(() => {
+        const main = this.document.getElementById('main-content');
+        main?.focus({ preventScroll: false });
+      });
+  }
 }

--- a/apps/web-app/src/index.html
+++ b/apps/web-app/src/index.html
@@ -7,7 +7,7 @@
   <base href="/" />
 
   <meta name="viewport"
-        content="width=device-width, initial-scale=1" />
+        content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
   <meta name="mobile-web-app-capable"
         content="yes" />
@@ -18,25 +18,41 @@
   <meta name="apple-mobile-web-app-title"
         content="Demo App" />
   <meta name="theme-color"
-        content="#fafafa" />
+        content="#fafafa"
+        media="(prefers-color-scheme: light)" />
+  <meta name="theme-color"
+        content="#171717"
+        media="(prefers-color-scheme: dark)" />
   <meta name="msapplication-navbutton-color"
         content="#fafafa" />
   <meta name="apple-mobile-web-app-status-bar-style"
         content="black-translucent" />
   <meta name="msapplication-starturl"
         content="/" />
-  <meta name="viewport"
-        content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="description"
-        content="A demo app using Angular CLI, Angular Material, NgRx platform, and .NET 3.0 + Microsoft.AspNetCore.SpaServices.Extensions" />
+        content="A starter template using Angular, Angular Material, NgRx Signals, Nx monorepo, and .NET — demonstrating modern tooling and best practices." />
+
+  <!-- Open Graph / Social sharing -->
+  <meta property="og:type"
+        content="website" />
+  <meta property="og:title"
+        content="Angular + NgRx + .NET Starter" />
+  <meta property="og:description"
+        content="A starter template using Angular, Angular Material, NgRx Signals, Nx monorepo, and .NET — demonstrating modern tooling and best practices." />
 
   <link rel="apple-touch-icon"
-        href="favicon.ico" />
-
+        href="assets/icons/icon-192x192.png" />
   <link rel="icon"
         type="image/x-icon"
         href="favicon.ico" />
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap"
+
+  <!-- Preconnect to speed up Google Fonts loading -->
+  <link rel="preconnect"
+        href="https://fonts.googleapis.com" />
+  <link rel="preconnect"
+        href="https://fonts.gstatic.com"
+        crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
         rel="stylesheet" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
         rel="stylesheet" />

--- a/apps/web-app/src/robots.txt
+++ b/apps/web-app/src/robots.txt
@@ -1,8 +1,2 @@
-User-Agent: slurp
-Disallow: /
-
-User-agent: baiduspider
-Disallow: /
-
-User-agent: yandex
-Disallow: /
+User-agent: *
+Allow: /

--- a/apps/web-app/src/styles/styles.css
+++ b/apps/web-app/src/styles/styles.css
@@ -42,6 +42,21 @@
       opacity: 0.6;
     }
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .loading {
+      animation: none;
+      opacity: 0.8;
+    }
+
+    *,
+    ::before,
+    ::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
 }
 
 markdown {

--- a/libs/login/src/lib/login/login.ts
+++ b/libs/login/src/lib/login/login.ts
@@ -35,11 +35,21 @@ import { LoginStore, getLoginFormGroup } from '../state/login.store';
           @if (!authStore.loginLoading()) {
             <mat-form-field appearance="outline">
               <mat-label>Email</mat-label>
-              <input matInput formControlName="email" />
+              <input
+                matInput
+                formControlName="email"
+                type="email"
+                autocomplete="email"
+              />
             </mat-form-field>
             <mat-form-field appearance="outline">
               <mat-label>Password</mat-label>
-              <input matInput formControlName="password" type="password" />
+              <input
+                matInput
+                formControlName="password"
+                type="password"
+                autocomplete="current-password"
+              />
             </mat-form-field>
           } @else {
             <div class="flex flex-col gap-4">

--- a/libs/shared/src/lib/components/main-toolbar.ts
+++ b/libs/shared/src/lib/components/main-toolbar.ts
@@ -36,7 +36,10 @@ import { NAV_LINKS } from './nav-links';
           fill="none"
           viewBox="0 0 223 236"
           width="32"
+          role="img"
+          aria-labelledby="angular-logo-title"
         >
+          <title id="angular-logo-title">Angular logo</title>
           <g clip-path="url(#a)">
             <path
               fill="url(#b)"

--- a/libs/weather-forecast/src/lib/components/weather-forecast/weather-forecast.spec.ts
+++ b/libs/weather-forecast/src/lib/components/weather-forecast/weather-forecast.spec.ts
@@ -36,7 +36,7 @@ describe('WeatherForecast', () => {
     const store = fixture.debugElement.injector.get(WeatherForecastStore);
     const getForecasts = vi.spyOn(store, 'getForecasts');
 
-    const input = screen.getByPlaceholderText('Forecast Days');
+    const input = screen.getByLabelText('Number of forecast days');
     await fireEvent.input(input, { target: { value: '5' } });
     await fireEvent.keyUp(input, { key: 'Enter' });
 

--- a/libs/weather-forecast/src/lib/components/weather-forecast/weather-forecast.ts
+++ b/libs/weather-forecast/src/lib/components/weather-forecast/weather-forecast.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { MatFormField } from '@angular/material/form-field';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
 import { AuthStore } from '@myorg/auth';
@@ -18,6 +18,7 @@ import { ForecastTable } from '../forecast-table/forecast-table';
     PageContainer,
     PageToolbarButton,
     MatFormField,
+    MatLabel,
     MatInput,
     PageToolbar,
     MatIcon,
@@ -28,11 +29,12 @@ import { ForecastTable } from '../forecast-table/forecast-table';
   template: `
     <lib-page-toolbar [title]="layoutStore.title()">
       <mat-form-field appearance="outline">
+        <mat-label>Forecast Days</mat-label>
         <input
           matInput
           #count
           type="number"
-          placeholder="Forecast Days"
+          [attr.aria-label]="'Number of forecast days'"
           (keyup.enter)="
             store.getForecasts({
               count: +count.value,


### PR DESCRIPTION
## Summary

Addresses both performance and accessibility audit findings.

Closes #28
Closes #29

## Changes

### perf (Issue #28)
- Remove duplicate `viewport` meta tag from `index.html`
- Add `preconnect` hints for Google Fonts to unblock rendering
- Update `robots.txt` to allow all crawlers (was blocking Slurp, Baidu, Yandex)
- Add `PreloadAllModules` route preloading strategy
- Add Open Graph meta tags; update app description

### a11y (Issue #29)
- Add skip-to-main-content link with keyboard focus management on route navigation
- Wrap `<router-outlet>` in `<main id="main-content">` landmark
- Add `role="img"` + `<title>` to Angular logo SVG in toolbar
- Add `type="email"` and `autocomplete` attributes to login form inputs
- Replace `placeholder` with `<mat-label>` + `aria-label` on forecast count input
- Add `prefers-reduced-motion` CSS rule to global styles
- Add dark-mode `theme-color` meta tag

## Testing
- All 38 tests pass (`nx run-many -t test`)
- Updated `weather-forecast.spec.ts` to use `getByLabelText` after placeholder removal